### PR TITLE
Fix Dockerfile, wrong .jar file name

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,8 @@ WORKDIR /bigquery-dlp-remote-function-src
 RUN gradle clean test assemble
 
 FROM eclipse-temurin:17-jre-focal
-COPY --from=build-test /bigquery-dlp-remote-function-src/build/libs/bigquery-dlp-remote-function-0.0.1-SNAPSHOT.jar .
+#file version in taken from build.gradle
+COPY --from=build-test /bigquery-dlp-remote-function-src/build/libs/bigquery-dlp-remote-function-0.1.0-SNAPSHOT.jar .
 # Run the web service on container startup.
 RUN groupadd -r apprunner && useradd -rm -g apprunner apprunner
 RUN chown apprunner ./bigquery-dlp-remote-function-0.0.1-SNAPSHOT.jar

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,6 @@ FROM eclipse-temurin:17-jre-focal
 COPY --from=build-test /bigquery-dlp-remote-function-src/build/libs/bigquery-dlp-remote-function-0.1.0-SNAPSHOT.jar .
 # Run the web service on container startup.
 RUN groupadd -r apprunner && useradd -rm -g apprunner apprunner
-RUN chown apprunner ./bigquery-dlp-remote-function-0.0.1-SNAPSHOT.jar
+RUN chown apprunner ./bigquery-dlp-remote-function-0.1.0-SNAPSHOT.jar
 USER apprunner
-CMD ["java", "-jar", "bigquery-dlp-remote-function-0.0.1-SNAPSHOT.jar"]
+CMD ["java", "-jar", "bigquery-dlp-remote-function-0.1.0-SNAPSHOT.jar"]


### PR DESCRIPTION
cloudbuild pipeline gets broken due to wrong .jar name, fixing and adding comment where to find this file name in future releases