### PR TITLE
chore: Add template_file_hash to triggers for auto-detecting changes

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -207,6 +207,7 @@ resource "null_resource" "dlp_de_identify_template" {
     region                       = var.region
     dlp_de_id_template_id        = local.template_id
     dlp_de_id_template_full_path = "projects/${var.project_id}/locations/${var.region}/deidentifyTemplates/${local.template_id}"
+    template_file_hash           = filesha256(var.dlp_deid_template_json_file)
   }
 
   provisioner "local-exec" {


### PR DESCRIPTION
## Changes

- Currently `null_resource` does not support detecting json config file's changes, to support auto-detecting changes in json config file, add template_file_hash value (with [filesha256 function](https://developer.hashicorp.com/terraform/language/functions/filesha256)) in triggers block for `null_resource.dlp_de_identify_template`.

## Test

After changes, test `terraform plan` command:

```bash
terraform plan \
  -var "project_id=<REDACTED>-dev" \
  -var "region=asia-northeast3"
```

Now resource.null_resource.dlp_de_identify_template can detect changes for template_file_hash value from local template file:

```bash
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
-/+ destroy and then create replacement

Terraform will perform the following actions:

  # null_resource.dlp_de_identify_template must be replaced
-/+ resource "null_resource" "dlp_de_identify_template" {
      ~ id       = "<REDACTED>" -> (known after apply)
      ~ triggers = { # forces replacement
          ~ "template_file_hash"           = "dd2370...REDACTED...bebf67" -> "c79ede...REDACTED...c26de5"
            # (4 unchanged elements hidden)
        }
    }

Plan: 1 to add, 0 to change, 1 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value:
```